### PR TITLE
Add a count action to count the number of elements in array

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -30,6 +30,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 r#"join(", ", addresses[0].street, addresses[0].postal, addresses[0].country)"#,
                 "address"
             ),
+            (r#"count(addresses)"#, "address_count"),
             ("nested.inner.key", "prev_nested"),
             ("nested.my_arr", "my_arr"),
             (r#"const("arr_value_2")"#, "my_arr[]")

--- a/src/actions/count.rs
+++ b/src/actions/count.rs
@@ -1,0 +1,116 @@
+use crate::action::Action;
+use crate::errors::Error;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use crate::actions::setter::Error as SetterError;
+use crate::parser::ParsableAction;
+use crate::Parser;
+use crate::parser::Error as ParseError;
+
+
+/// This type represents an [Action](../action/trait.Action.html) which counts the number of elements
+/// in the given array.
+///
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Count {
+    value: Box<dyn Action>,
+}
+
+impl Count {
+    pub fn new(value: Box<dyn Action>) -> Self {
+        Self { value }
+    }
+}
+
+#[typetag::serde]
+impl Action for Count {
+    fn apply(&self, source: &Value, destination: &mut Value) -> Result<Option<Value>, Error> {
+        let result = match self.value.apply(source, destination)? {
+            Some(v) => {
+                match v {
+                    Value::Array(l) => Ok(l.len()),
+                    Value::String(_) => {
+                        Err(SetterError::InvalidDestinationType {
+                            err: format!("Attempting get count of string, expected array. {:?}", self.value),
+                        })
+                    }
+                    Value::Null => {
+                        Err(SetterError::InvalidDestinationType {
+                            err: format!("Attempting get count of null, expected array. {:?}", self.value),
+                        })
+                    }
+                    Value::Number(_) => {
+                        Err(SetterError::InvalidDestinationType {
+                            err: format!("Attempting get count of number, expected array. {:?}", self.value),
+                        })
+                    }
+                    Value::Bool(_) => {
+                        Err(SetterError::InvalidDestinationType {
+                            err: format!("Attempting get count of bool, expected array. {:?}", self.value),
+                        })
+                    }
+                    Value::Object(_) => {
+                        Err(SetterError::InvalidDestinationType {
+                            err: format!("Attempting get count of object, expected array. {:?}", self.value),
+                        })
+                    }
+                }
+            }
+            None => Ok(0 as usize),
+        };
+
+        let res = result?;
+        Ok(Some(Value::Number(res.into())))
+    }
+}
+
+
+#[derive(Debug)]
+pub struct ParsableCount;
+
+impl ParsableAction for ParsableCount {
+    fn parse(&self, parser: &Parser, value: &str) -> Result<Box<dyn Action>, ParseError> {
+        let action = parser.get_action(value.trim()).unwrap();
+        Ok(Box::new(Count::new(action)))
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use crate::actions::Getter;
+    use crate::actions::getter::namespace::Namespace as GetterNamespace;
+
+    #[test]
+    fn count_array_in_namespace() -> Result<(), Box<dyn std::error::Error>> {
+        let input = json!({"key":["value1", "value2"]});
+        let mut value = Value::Null;
+        let counter = Count::new(Box::new(Getter::new(GetterNamespace::parse("key")?)));
+        let res = counter.apply(&input, &mut value)?;
+        assert_eq!(res.unwrap(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn count_raw_array() -> Result<(), Box<dyn std::error::Error>> {
+        let input = json!(["value1", "value2"]);
+        let mut value = Value::Null;
+        let counter = Count::new(Box::new(Getter::new(GetterNamespace::parse("")?)));
+        let res = counter.apply(&input, &mut value)?;
+        assert_eq!(res.unwrap(), 2);
+        Ok(())
+    }
+
+    #[test]
+    #[should_panic(expected = "expected array")]
+    fn count_string_error() {
+        let input = json!("value1");
+        let mut value = Value::Null;
+        let counter = Count::new(Box::new(Getter::new(GetterNamespace::parse("").unwrap())));
+        let res = counter.apply(&input, &mut value);
+        res.unwrap();
+    }
+
+}

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -4,6 +4,7 @@ mod constant;
 pub mod getter;
 mod join;
 pub mod setter;
+mod count;
 
 #[doc(inline)]
 pub use constant::Constant;
@@ -15,7 +16,11 @@ pub use getter::Getter;
 pub use join::Join;
 
 #[doc(inline)]
+pub use count::Count;
+
+#[doc(inline)]
 pub use setter::Setter;
 
 pub(crate) use constant::ParsableConst;
 pub(crate) use join::ParsableJoin;
+pub(crate) use count::ParsableCount;

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1,7 +1,7 @@
 use crate::action::Action;
 use crate::actions::getter::namespace::Namespace as GetterNamespace;
 use crate::actions::setter::namespace::Namespace as SetterNamespace;
-use crate::actions::{Getter, ParsableConst, ParsableJoin, Setter};
+use crate::actions::{Getter, ParsableConst, ParsableJoin, Setter, ParsableCount};
 use crate::parser::errors::Error;
 use crate::parser::ParsableAction;
 use lazy_static::lazy_static;
@@ -55,6 +55,7 @@ impl Default for ParserBuilder {
         let mut actions: HashMap<String, Box<dyn ParsableAction>> = HashMap::new();
         actions.insert("const".to_string(), Box::new(ParsableConst));
         actions.insert("join".to_string(), Box::new(ParsableJoin));
+        actions.insert("count".to_string(), Box::new(ParsableCount));
         Self { actions }
     }
 }


### PR DESCRIPTION
Hi!

This adds simple "count" action to count the number of elements in array.

I was just testing how each it was to add a new action :)

It gives an error for all non-array types. We could definitely consider allowing counting objects by returning the number of keys in the object if it makes sense.